### PR TITLE
add tzdata to enable changing Timezone with ENV variable TZ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM alpine:3.9
 
-RUN apk add --no-cache mysql-client
+RUN apk add --no-cache \
+    mysql-client \
+    tzdata
 ENTRYPOINT ["crond", "-f"]


### PR DESCRIPTION
By installing tzdata, we can change easily change timezone with TZ variable in docker-compose file
Since crontabs are highly related to time, i think it is important to be able to do it !